### PR TITLE
Revert "Fix Coe Issues"

### DIFF
--- a/src/main/java/seedu/address/logic/filters/Filters.java
+++ b/src/main/java/seedu/address/logic/filters/Filters.java
@@ -25,19 +25,23 @@ public class Filters {
 
 
         if (argumentMultimap.getTotalSize() > 2) { // since there is also a dummy position :(
+            System.out.println(argumentMultimap);
             throw new NullPointerException(
                 "Number of filters between two logical operators should be exactly 1 " + argumentMultimap);
         }
 
         if (argumentMultimap.getValue(PREFIX_EMAIL).isPresent()) {
+            System.out.println(100);
             return new EmailFilter(argumentMultimap.getValue(PREFIX_EMAIL).get());
         }
 
         if (argumentMultimap.getValue(PREFIX_PHONE).isPresent()) {
+            System.out.println(100);
             return new PhoneNumberFilter(argumentMultimap.getValue(PREFIX_PHONE).get());
         }
 
         if (argumentMultimap.getValue(PREFIX_COE_EXPIRY).isPresent()) {
+            System.out.println(100);
             return new CoeExpiryFilter(argumentMultimap.getValue(PREFIX_COE_EXPIRY).get());
         }
 


### PR DESCRIPTION
Reverts AY2021S2-CS2103T-W12-2/tp#150

This is because @OhJunMing accidently removed the part of the commit that actually fixed the problem. 

This being the fact that `coe/` contained `e/` as a postfix





















